### PR TITLE
applied patch

### DIFF
--- a/probe-rs/src/flashing/erase.rs
+++ b/probe-rs/src/flashing/erase.rs
@@ -232,3 +232,16 @@ pub fn erase_sectors(
 
     Ok(())
 }
+
+// TODO: move it to a separate file
+pub fn read_mem(session: &mut Session, address: u64, data: &mut [u8]) -> Result<(), FlashError> {
+
+    let algo = session.target().flash_algorithms[0].clone();
+
+    let mut flasher = Flasher::new(session, 0, &algo, FlashProgress::new(|_| {}))?;
+
+    flasher.verify_custom(address, data);
+
+    Ok(())
+}
+

--- a/probe-rs/src/flashing/flasher.rs
+++ b/probe-rs/src/flashing/flasher.rs
@@ -335,6 +335,14 @@ impl<'session> Flasher<'session> {
         result
     }
 
+    pub(super) fn verify_custom(&mut self, address: u64, data: &mut [u8]) -> Result<(), FlashError> {
+        self.run_verify(|active| {
+            active.read_flash(address, data);
+            Ok(true)
+        });
+        Ok(())
+    }
+
     /// Verifies all the to-be-written bytes of `layout`.
     pub(super) fn verify(
         &mut self,

--- a/target-gen/src/commands/test.rs
+++ b/target-gen/src/commands/test.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
 use probe_rs::{
     flashing::{
-        erase_all, erase_sectors, DownloadOptions, FlashLoader, FlashProgress, ProgressEvent,
+        erase_all, erase_sectors, read_mem, DownloadOptions, FlashLoader, FlashProgress, ProgressEvent,
     },
     MemoryInterface, Permissions, Session,
 };
@@ -164,9 +164,10 @@ pub fn cmd_test(
     println!("{test}: Erase done");
 
     let mut readback = vec![0; (sector_size * 2) as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address, &mut readback)?;
     assert!(
         readback.iter().all(|v| *v == erased_state),
         "Not all sectors were erased"
@@ -182,18 +183,20 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address + 1, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address + 1, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing the entire chip and writing two pages ...");
     run_flash_erase(&mut session, progress.clone(), EraseType::EraseAll)?;
     println!("{test}: Erase done");
     let mut readback = vec![0; (sector_size * 2) as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address + 1, &mut readback)?;
     assert!(
         readback.iter().all(|v| *v == erased_state),
         "Not all sectors were erased"
@@ -208,9 +211,10 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address + 1, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address + 1, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     println!("{test}: Erasing sectorwise and writing two pages double buffered ...");
@@ -222,9 +226,10 @@ pub fn cmd_test(
     println!("{test}: Erase done");
 
     let mut readback = vec![0; (sector_size * 2) as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address, &mut readback)?;
     assert!(
         readback.iter().all(|v| *v == erased_state),
         "Not all sectors were erased"
@@ -238,9 +243,10 @@ pub fn cmd_test(
     println!("{test}: Write done");
 
     let mut readback = vec![0; data_size as usize];
-    session
-        .core(0)?
-        .read_8(test_start_sector_address + 1, &mut readback)?;
+    // session
+    //     .core(0)?
+    //     .read_8(test_start_sector_address + 1, &mut readback)?;
+    read_mem(&mut session, test_start_sector_address + 1, &mut readback)?;
     assert_eq!(readback, data);
 
     Ok(())

--- a/target-gen/src/parser.rs
+++ b/target-gen/src/parser.rs
@@ -98,6 +98,8 @@ pub fn extract_flash_algo(
 
             _ => {}
         }
+        // TODO: it's not possible to set stack_size from config/yaml file
+        algo.stack_size = Some(4096);
     }
 
     if fixed_load_address {


### PR DESCRIPTION
The current status of the branch `target-gen-utilize-read-flash-func` doesn't match https://github.com/probe-rs/probe-rs/tree/849498d with applied patch from https://discord.com/channels/1224691031874867230/1230823877261656125/1321082697048916009, neither does it work with https://github.com/pkoevesdi/STM32h750xx_MT25QL512ABB/tree/30cd5d4efc54d304078f0304143d3de63c309410
To have a online-reference for a working probe-rs for the latter I made this commit with Your patch.